### PR TITLE
Add GITHUB_TOKEN to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,3 +40,4 @@ jobs:
             pnpm changeset publish -r
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This update ensures the publish workflow has access to the GITHUB_TOKEN secret. It is required for certain GitHub-related operations during the publish process.