### PR TITLE
Chore/add utils

### DIFF
--- a/.changeset/whole-bears-decide.md
+++ b/.changeset/whole-bears-decide.md
@@ -1,0 +1,8 @@
+---
+"@onderwijsin/directus-extension-cache-flush": patch
+"@onderwijsin/directus-extension-data-sync": patch
+"utils": patch
+---
+
+Add pruneObjByFieldKeys to utils
+Add a reusable utility fn to workspace utils. Implements it in data sync and cache flush

--- a/packages/directus-extension-cache-flush/package.json
+++ b/packages/directus-extension-cache-flush/package.json
@@ -3,6 +3,7 @@
 	"description": "Send requests to external applications to flush cache upon data changes",
 	"icon": "extension",
 	"version": "1.0.0",
+	"license": "MIT",
 	"author": {
 		"name": "Onderwijs in",
 		"email": "hallo@onderwijs.in",

--- a/packages/directus-extension-cache-flush/src/flush.ts
+++ b/packages/directus-extension-cache-flush/src/flush.ts
@@ -2,8 +2,8 @@ import { ofetch } from 'ofetch';
 import { EventContext, PrimaryKey } from '@directus/types';
 import { ApiExtensionContext } from '@directus/extensions';
 import type { Meta, FlushConfig, RecordData } from './types';
-import { createNotifcation } from 'utils';
-import { prunePayload, fetchExistingFieldData } from './utils';
+import { createNotifcation, pruneObjByFieldKeys } from 'utils';
+import { fetchExistingFieldData } from './utils';
 
 export const sendFlushRequest = async (
     meta: Meta,
@@ -54,7 +54,7 @@ export const sendFlushRequest = async (
         let payload = {
             collection: meta.collection,
             event: 'create',
-            fields: prunePayload(meta.payload, collection.payload),
+            fields: pruneObjByFieldKeys(meta.payload, collection.payload),
             timestamp: Date.now()
         }
 
@@ -99,7 +99,7 @@ export const sendFlushRequest = async (
         let payload = {
             collection: meta.collection,
             event: 'update',
-            fields: prunePayload(meta.payload, collection.payload),
+            fields: pruneObjByFieldKeys(meta.payload, collection.payload),
             timestamp: Date.now()
         }
 
@@ -127,7 +127,7 @@ export const sendFlushRequest = async (
                 // Directus converts integer ids to strings...
                 const record = data.find(d => d.id === key || typeof d.id === 'number' && typeof key === 'string' ? parseInt(key as string) === d.id : false)
                 if (!record) return
-                payload.fields = prunePayload(record, collection.payload)
+                payload.fields = pruneObjByFieldKeys(record, collection.payload)
             }
 
             try {
@@ -179,7 +179,7 @@ export const sendFlushRequest = async (
             if (!recordData) return
             const record = recordData.find(d => d.id === key)
             if (!record) return
-            payload.fields = prunePayload(record, collection.payload)
+            payload.fields = pruneObjByFieldKeys(record, collection.payload)
 
             try {
                 await ofetch(url, {

--- a/packages/directus-extension-cache-flush/src/flush.ts
+++ b/packages/directus-extension-cache-flush/src/flush.ts
@@ -2,7 +2,7 @@ import { ofetch } from 'ofetch';
 import { EventContext, PrimaryKey } from '@directus/types';
 import { ApiExtensionContext } from '@directus/extensions';
 import type { Meta, FlushConfig, RecordData } from './types';
-import { createNotifcation, pruneObjByFieldKeys } from 'utils';
+import { createNotifcation, pruneObjByKeys } from 'utils';
 import { fetchExistingFieldData } from './utils';
 
 export const sendFlushRequest = async (
@@ -54,7 +54,7 @@ export const sendFlushRequest = async (
         let payload = {
             collection: meta.collection,
             event: 'create',
-            fields: pruneObjByFieldKeys(meta.payload, collection.payload),
+            fields: pruneObjByKeys(meta.payload, collection.payload),
             timestamp: Date.now()
         }
 
@@ -99,7 +99,7 @@ export const sendFlushRequest = async (
         let payload = {
             collection: meta.collection,
             event: 'update',
-            fields: pruneObjByFieldKeys(meta.payload, collection.payload),
+            fields: pruneObjByKeys(meta.payload, collection.payload),
             timestamp: Date.now()
         }
 
@@ -127,7 +127,7 @@ export const sendFlushRequest = async (
                 // Directus converts integer ids to strings...
                 const record = data.find(d => d.id === key || typeof d.id === 'number' && typeof key === 'string' ? parseInt(key as string) === d.id : false)
                 if (!record) return
-                payload.fields = pruneObjByFieldKeys(record, collection.payload)
+                payload.fields = pruneObjByKeys(record, collection.payload)
             }
 
             try {
@@ -179,7 +179,7 @@ export const sendFlushRequest = async (
             if (!recordData) return
             const record = recordData.find(d => d.id === key)
             if (!record) return
-            payload.fields = pruneObjByFieldKeys(record, collection.payload)
+            payload.fields = pruneObjByKeys(record, collection.payload)
 
             try {
                 await ofetch(url, {

--- a/packages/directus-extension-cache-flush/src/utils.ts
+++ b/packages/directus-extension-cache-flush/src/utils.ts
@@ -73,20 +73,6 @@ export const fetchCacheFlushConfig = async (eventContext: EventContext, context:
 }
 
 
-export const prunePayload = (
-    payload: Record<string, any>, 
-    fields: string[]
-): Record<string, any> => {
-    return Object.keys(payload).reduce((acc, key) => {
-        if (fields.find(f => f === key)) {
-            acc[key] = payload[key]
-        }
-        return acc
-    }, {} as Record<string, any>)
-}
-
-
-
 /**
  * Fetches additional fields for the given meta data.
  *

--- a/packages/directus-extension-data-sync/src/sync.ts
+++ b/packages/directus-extension-data-sync/src/sync.ts
@@ -1,9 +1,8 @@
 import { ApiExtensionContext } from '@directus/extensions';
 import type { Meta, RemoteConfig } from './types';
-import { prunePayload } from './utils';
 import { ofetch } from 'ofetch';
 import { EventContext } from '@directus/types';
-import { createNotifcation } from 'utils'
+import { createNotifcation, pruneObjByFieldKeys } from 'utils'
 
 export const syncData = async (
     meta: Meta, 
@@ -78,7 +77,7 @@ export const syncData = async (
     
         } else if (meta.event === 'items.create') {
                 logger.info('Syncing created item to remote: ' + remote.url);
-                const prunedPayload = prunePayload(meta.payload, collection.fields);
+                const prunedPayload = pruneObjByFieldKeys(meta.payload, collection.fields);
 
 
                 /* NOTE
@@ -132,7 +131,7 @@ export const syncData = async (
                 This should always be the case, but for redundancy, we will send
                 individual requests for each item.
             */
-            const prunedPayload = prunePayload(meta.payload, collection.fields);
+            const prunedPayload = pruneObjByFieldKeys(meta.payload, collection.fields);
 
             // If the pruned payload is empty, we do not want to send a request to the remote
             // since none of the sync fields are changed

--- a/packages/directus-extension-data-sync/src/sync.ts
+++ b/packages/directus-extension-data-sync/src/sync.ts
@@ -2,7 +2,7 @@ import { ApiExtensionContext } from '@directus/extensions';
 import type { Meta, RemoteConfig } from './types';
 import { ofetch } from 'ofetch';
 import { EventContext } from '@directus/types';
-import { createNotifcation, pruneObjByFieldKeys } from 'utils'
+import { createNotifcation, pruneObjByKeys } from 'utils'
 
 export const syncData = async (
     meta: Meta, 
@@ -77,7 +77,7 @@ export const syncData = async (
     
         } else if (meta.event === 'items.create') {
                 logger.info('Syncing created item to remote: ' + remote.url);
-                const prunedPayload = pruneObjByFieldKeys(meta.payload, collection.fields);
+                const prunedPayload = pruneObjByKeys(meta.payload, collection.fields);
 
 
                 /* NOTE
@@ -131,7 +131,7 @@ export const syncData = async (
                 This should always be the case, but for redundancy, we will send
                 individual requests for each item.
             */
-            const prunedPayload = pruneObjByFieldKeys(meta.payload, collection.fields);
+            const prunedPayload = pruneObjByKeys(meta.payload, collection.fields);
 
             // If the pruned payload is empty, we do not want to send a request to the remote
             // since none of the sync fields are changed

--- a/packages/directus-extension-data-sync/src/utils.ts
+++ b/packages/directus-extension-data-sync/src/utils.ts
@@ -64,19 +64,6 @@ export const assignPolicy = async (context: ApiExtensionContext) => {
 }
 
 
-export const prunePayload = (
-    payload: Record<string, any>, 
-    fields: string[]
-): Record<string, any> => {
-    return Object.keys(payload).reduce((acc, key) => {
-        if (fields.find(f => f === key)) {
-            acc[key] = payload[key]
-        }
-        return acc
-    }, {} as Record<string, any>)
-}
-
-
 export const fetchRemotes = async (eventContext: EventContext, context: ApiExtensionContext): Promise<RemoteConfig[]> => {
     const { ItemsService } = context.services
     const items: ItemsService = new ItemsService('data_sync_remote_sources', {

--- a/utils/package.json
+++ b/utils/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.ts",
   "types": "src/index.d.ts",
   "type": "module",
+  "license": "MIT",
   "devDependencies": {
     "@directus/api": "^24.0.1",
     "@directus/extensions": "^3.0.2",

--- a/utils/src/helpers.ts
+++ b/utils/src/helpers.ts
@@ -39,7 +39,7 @@ export const disableSchemaChange = (extension_key: string, env: ApiExtensionCont
  * @param keys - The array of keys to retain in the object.
  * @returns A new object containing only the specified keys from the original object.
  */
-export const pruneObjByFieldKeys = <T extends Record<string, any>, K extends keyof T>(
+export const pruneObjByKeys = <T extends Record<string, any>, K extends keyof T>(
     obj: T, 
     keys: K[]
 ): Partial<Pick<T, K>> => {

--- a/utils/src/helpers.ts
+++ b/utils/src/helpers.ts
@@ -28,3 +28,25 @@ export const disableSchemaChange = (extension_key: string, env: ApiExtensionCont
     const { DISABLE_EXTENSION_SCHEMA_CHANGE } = env;
     return (!!env[extension_key] && (env[extension_key] === 'true' || env[extension_key] === true)) || (!!DISABLE_EXTENSION_SCHEMA_CHANGE && (DISABLE_EXTENSION_SCHEMA_CHANGE === 'true' || DISABLE_EXTENSION_SCHEMA_CHANGE === true))
 };
+
+
+
+
+/**
+ * Prunes an object by retaining only the specified keys.
+ *
+ * @param obj - The object to prune.
+ * @param keys - The array of keys to retain in the object.
+ * @returns A new object containing only the specified keys from the original object.
+ */
+export const pruneObjByFieldKeys = <T extends Record<string, any>, K extends keyof T>(
+    obj: T, 
+    keys: K[]
+): Partial<Pick<T, K>> => {
+    return Object.keys(obj).reduce((acc, key) => {
+        if (keys.includes(key as K)) {
+            acc[key as K] = obj[key];
+        }
+        return acc;
+    }, {} as Partial<Pick<T, K>>);
+}


### PR DESCRIPTION
This pull request introduces a new utility function `pruneObjByKeys` and integrates it into the `directus-extension-cache-flush` and `directus-extension-data-sync` packages. Additionally, it updates the license information for several packages.

### New Utility Function:
* Added `pruneObjByKeys` function to `utils/src/helpers.ts` to prune objects by retaining only specified keys.

### Integration of `pruneObjByKeys`:
* Replaced `prunePayload` with `pruneObjByKeys` in `sendFlushRequest` function in `packages/directus-extension-cache-flush/src/flush.ts`. [[1]](diffhunk://#diff-c615c91caa321c4b7732a557b9e2a876cfe0715bada2fa21eb8a93880de62011L57-R57) [[2]](diffhunk://#diff-c615c91caa321c4b7732a557b9e2a876cfe0715bada2fa21eb8a93880de62011L102-R102) [[3]](diffhunk://#diff-c615c91caa321c4b7732a557b9e2a876cfe0715bada2fa21eb8a93880de62011L130-R130) [[4]](diffhunk://#diff-c615c91caa321c4b7732a557b9e2a876cfe0715bada2fa21eb8a93880de62011L182-R182)
* Replaced `prunePayload` with `pruneObjByKeys` in `syncData` function in `packages/directus-extension-data-sync/src/sync.ts`. [[1]](diffhunk://#diff-00f9663fd900c912ecad7e6e9603937074d69a20b520a08725f7a754dae82f9bL81-R80) [[2]](diffhunk://#diff-00f9663fd900c912ecad7e6e9603937074d69a20b520a08725f7a754dae82f9bL135-R134)

### Removal of Deprecated Function:
* Removed the deprecated `prunePayload` function from `packages/directus-extension-cache-flush/src/utils.ts` and `packages/directus-extension-data-sync/src/utils.ts`. [[1]](diffhunk://#diff-c6b07a2447da08266d92ad04bcf9f4f247ec75b3c14f454a0c88ec38603f3389L76-L89) [[2]](diffhunk://#diff-70ddd7647d3bff315f680a42402a31beb532bc23dd7ae4808044788def084245L67-L79)

### License Updates:
* Added MIT license to `packages/directus-extension-cache-flush/package.json`.
* Added MIT license to `utils/package.json`.

### Changeset:
* Documented the changes in `.changeset/whole-bears-decide.md`.