### PR TITLE
fix(sluggernaut): Remove meta id from schema

### DIFF
--- a/packages/directus-bundle-sluggernaut/src/redirect-hooks/schema.ts
+++ b/packages/directus-bundle-sluggernaut/src/redirect-hooks/schema.ts
@@ -431,7 +431,6 @@ export const settingsFieldSchema = [
 		"type": "alias",
 		"schema": null,
 		"meta": {
-			"id": 165,
 			"collection": "directus_settings",
 			"field": "divider_redirects",
 			"special": [


### PR DESCRIPTION
This pull request includes a small change to the `settingsFieldSchema` in the `packages/directus-bundle-sluggernaut/src/redirect-hooks/schema.ts` file. The change removes the "id" field from the "meta" object within the schema definition.

* [`packages/directus-bundle-sluggernaut/src/redirect-hooks/schema.ts`](diffhunk://#diff-c6d007cfecf0fc64a5bbeb3198b0113b8da9e973fc71d497fb403a88994cadcfL434): Removed the "id" field from the "meta" object in the `settingsFieldSchema`.