### PR TITLE
feat: Use zod for schema validation

### DIFF
--- a/.changeset/sixty-shoes-double.md
+++ b/.changeset/sixty-shoes-double.md
@@ -1,0 +1,6 @@
+---
+"@onderwijsin/directus-extension-cache-flush": patch
+"@onderwijsin/directus-extension-data-sync": patch
+---
+
+Use zod for schema validation in cache-flush and data-sync. Validates the schema's provided in the config collections, and logs any errors

--- a/packages/directus-extension-cache-flush/package.json
+++ b/packages/directus-extension-cache-flush/package.json
@@ -43,7 +43,8 @@
 		"@directus/extensions-sdk": "13.0.3",
 		"@directus/types": "^13.0.0",
 		"@types/node": "^22.13.9",
-		"typescript": "^5.8.2"
+		"typescript": "^5.8.2",
+		"zod": "^3.24.2"
 	},
 	"dependencies": {
 		"ofetch": "^1.4.1",

--- a/packages/directus-extension-data-sync/package.json
+++ b/packages/directus-extension-data-sync/package.json
@@ -44,7 +44,8 @@
 		"@directus/extensions-sdk": "13.0.3",
 		"@directus/types": "^13.0.0",
 		"@types/node": "^22.13.9",
-		"typescript": "^5.8.2"
+		"typescript": "^5.8.2",
+		"zod": "^3.24.2"
 	},
 	"dependencies": {
 		"ofetch": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 2.0.0
       '@directus/types':
         specifier: ^13.0.0
-        version: 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+        version: 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@microsoft/microsoft-graph-client':
         specifier: ^3.0.7
         version: 3.0.7(@azure/identity@4.7.0)
@@ -62,10 +62,10 @@ importers:
         version: 24.0.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions':
         specifier: ^3.0.2
-        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions-sdk':
         specifier: 13.0.3
-        version: 13.0.3(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
+        version: 13.0.3(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
       '@types/node':
         specifier: ^22.13.5
         version: 22.13.5
@@ -93,13 +93,13 @@ importers:
         version: 2.0.0
       '@directus/extensions':
         specifier: ^3.0.2
-        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions-sdk':
         specifier: 13.0.3
-        version: 13.0.3(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
+        version: 13.0.3(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
       '@directus/types':
         specifier: ^13.0.0
-        version: 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+        version: 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@types/node':
         specifier: ^22.13.5
         version: 22.13.5
@@ -133,16 +133,19 @@ importers:
         version: 3.0.3(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions-sdk':
         specifier: 13.0.3
-        version: 13.0.3(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
+        version: 13.0.3(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
       '@directus/types':
         specifier: ^13.0.0
-        version: 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+        version: 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@types/node':
         specifier: ^22.13.9
         version: 22.13.9
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
 
   packages/directus-extension-data-sync:
     dependencies:
@@ -161,19 +164,22 @@ importers:
         version: 2.0.0
       '@directus/extensions':
         specifier: ^3.0.2
-        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions-sdk':
         specifier: 13.0.3
-        version: 13.0.3(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
+        version: 13.0.3(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
       '@directus/types':
         specifier: ^13.0.0
-        version: 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+        version: 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@types/node':
         specifier: ^22.13.9
         version: 22.13.9
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
 
   packages/directus-extension-slugify-operation:
     dependencies:
@@ -192,7 +198,7 @@ importers:
         version: 13.0.3(@types/node@22.13.4)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
       '@directus/types':
         specifier: ^13.0.0
-        version: 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+        version: 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@types/node':
         specifier: ^22.13.4
         version: 22.13.4
@@ -214,13 +220,13 @@ importers:
         version: 24.0.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions':
         specifier: ^3.0.2
-        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+        version: 3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/tsconfig':
         specifier: 3.0.0
         version: 3.0.0
       '@directus/types':
         specifier: ^13.0.0
-        version: 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+        version: 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@types/node':
         specifier: ^22.13.4
         version: 22.13.5
@@ -7047,7 +7053,7 @@ snapshots:
       date-fns: 4.1.0
       deep-diff: 1.0.2
       destroy: 1.2.0
-      directus: 11.4.1(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+      directus: 11.4.1(@types/node@22.13.4)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       dotenv: 16.4.7
       encodeurl: 2.0.0
       eventemitter2: 6.4.9
@@ -7207,7 +7213,7 @@ snapshots:
       '@directus/errors': 2.0.0
       '@directus/extensions': 3.0.1(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions-registry': 3.0.1(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-      '@directus/extensions-sdk': 13.0.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
+      '@directus/extensions-sdk': 13.0.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
       '@directus/format-title': 12.0.0
       '@directus/memory': 3.0.0(vue@3.5.13(typescript@5.8.2))
       '@directus/pressure': 3.0.0(vue@3.5.13(typescript@5.8.2))
@@ -7246,7 +7252,7 @@ snapshots:
       date-fns: 4.1.0
       deep-diff: 1.0.2
       destroy: 1.2.0
-      directus: 11.4.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+      directus: 11.4.1(@types/node@22.13.4)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       dotenv: 16.4.7
       encodeurl: 2.0.0
       eventemitter2: 6.4.9
@@ -7406,7 +7412,7 @@ snapshots:
       '@directus/errors': 2.0.0
       '@directus/extensions': 3.0.1(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/extensions-registry': 3.0.1(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-      '@directus/extensions-sdk': 13.0.1(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
+      '@directus/extensions-sdk': 13.0.1(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))
       '@directus/format-title': 12.0.0
       '@directus/memory': 3.0.0(vue@3.5.13(typescript@5.8.2))
       '@directus/pressure': 3.0.0(vue@3.5.13(typescript@5.8.2))
@@ -7709,7 +7715,7 @@ snapshots:
       - typescript
       - vue-router
 
-  '@directus/extensions-sdk@13.0.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
+  '@directus/extensions-sdk@13.0.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
     dependencies:
       '@directus/composables': 11.1.6(vue@3.5.13(typescript@5.8.2))
       '@directus/constants': 13.0.0
@@ -7761,7 +7767,7 @@ snapshots:
       - typescript
       - vue-router
 
-  '@directus/extensions-sdk@13.0.1(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
+  '@directus/extensions-sdk@13.0.1(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(mysql2@3.12.0)(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(sqlite3@5.1.7)(tedious@18.6.1)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
     dependencies:
       '@directus/composables': 11.1.6(vue@3.5.13(typescript@5.8.2))
       '@directus/constants': 13.0.0
@@ -7819,7 +7825,7 @@ snapshots:
       '@directus/constants': 13.0.0
       '@directus/extensions': 3.0.3(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/themes': 1.0.9(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-      '@directus/types': 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+      '@directus/types': 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@directus/utils': 13.0.2(vue@3.5.13(typescript@5.8.2))
       '@rollup/plugin-commonjs': 25.0.8(rollup@3.29.5)
       '@rollup/plugin-json': 6.1.0(rollup@3.29.5)
@@ -7865,13 +7871,13 @@ snapshots:
       - typescript
       - vue-router
 
-  '@directus/extensions-sdk@13.0.3(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
+  '@directus/extensions-sdk@13.0.3(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
     dependencies:
       '@directus/composables': 11.1.8(vue@3.5.13(typescript@5.8.2))
       '@directus/constants': 13.0.0
       '@directus/extensions': 3.0.3(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/themes': 1.0.9(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-      '@directus/types': 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+      '@directus/types': 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@directus/utils': 13.0.2(vue@3.5.13(typescript@5.8.2))
       '@rollup/plugin-commonjs': 25.0.8(rollup@3.29.5)
       '@rollup/plugin-json': 6.1.0(rollup@3.29.5)
@@ -7917,13 +7923,13 @@ snapshots:
       - typescript
       - vue-router
 
-  '@directus/extensions-sdk@13.0.3(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
+  '@directus/extensions-sdk@13.0.3(@types/node@22.13.9)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))':
     dependencies:
       '@directus/composables': 11.1.8(vue@3.5.13(typescript@5.8.2))
       '@directus/constants': 13.0.0
       '@directus/extensions': 3.0.3(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/themes': 1.0.9(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-      '@directus/types': 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+      '@directus/types': 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@directus/utils': 13.0.2(vue@3.5.13(typescript@5.8.2))
       '@rollup/plugin-commonjs': 25.0.8(rollup@3.29.5)
       '@rollup/plugin-json': 6.1.0(rollup@3.29.5)
@@ -7996,11 +8002,11 @@ snapshots:
       - supports-color
       - tedious
 
-  '@directus/extensions@3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))':
+  '@directus/extensions@3.0.2(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(pino@9.6.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))':
     dependencies:
       '@directus/constants': 13.0.0
       '@directus/themes': 1.0.8(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-      '@directus/types': 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+      '@directus/types': 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@directus/utils': 13.0.1(vue@3.5.13(typescript@5.8.2))
       '@types/express': 4.17.21
       fs-extra: 11.2.0
@@ -8027,7 +8033,7 @@ snapshots:
     dependencies:
       '@directus/constants': 13.0.0
       '@directus/themes': 1.0.9(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-      '@directus/types': 13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
+      '@directus/types': 13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))
       '@directus/utils': 13.0.2(vue@3.5.13(typescript@5.8.2))
       '@types/express': 4.17.21
       fs-extra: 11.2.0
@@ -8185,7 +8191,7 @@ snapshots:
 
   '@directus/tsconfig@3.0.0': {}
 
-  '@directus/types@13.0.0(knex@3.1.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))':
+  '@directus/types@13.0.0(knex@3.1.0(pg@8.13.1))(pg@8.13.1)(vue@3.5.13(typescript@5.8.2))':
     dependencies:
       '@directus/constants': 13.0.0
       '@directus/schema': 13.0.0(mysql2@3.12.0)(pg@8.13.1)(sqlite3@5.1.7)(tedious@18.6.1)
@@ -10586,9 +10592,9 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  directus@11.4.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2)):
+  directus@11.4.1(@types/node@22.13.4)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2)):
     dependencies:
-      '@directus/api': 24.0.1(@types/node@22.13.5)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+      '@directus/api': 24.0.1(@types/node@22.13.4)(@unhead/vue@1.11.19(vue@3.5.13(typescript@5.8.2)))(encoding@0.1.13)(lodash@4.17.21)(pinia@2.3.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(terser@5.39.0)(typescript@5.8.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
       '@directus/update-check': 13.0.0
     transitivePeerDependencies:
       - '@types/node'


### PR DESCRIPTION
This pull request introduces the `zod` library for schema validation and updates dependencies across multiple packages. The most significant changes include the addition of `zod` for schema validation in the `directus-extension-cache-flush` and `directus-extension-data-sync` packages, and updates to the `pnpm-lock.yaml` file to reflect these changes.

### Schema Validation Enhancements:
* Added `zod` library for schema validation in `packages/directus-extension-cache-flush/package.json` and `packages/directus-extension-data-sync/package.json`. [[1]](diffhunk://#diff-b0639c6c548596b6e98a68f93f26b3dc524b93c94a235f4a4ff5d1a88cb8ac4aL46-R47) [[2]](diffhunk://#diff-044e0f97f4d4e390acdcfa1206d07abaadfdd6b1d7ca53a12331b1488e7b7592L47-R48)
* Implemented `schemaValidator` using `zod` in `packages/directus-extension-cache-flush/src/utils.ts` and `packages/directus-extension-data-sync/src/utils.ts`. [[1]](diffhunk://#diff-c6b07a2447da08266d92ad04bcf9f4f247ec75b3c14f454a0c88ec38603f3389R8-R18) [[2]](diffhunk://#diff-70ddd7647d3bff315f680a42402a31beb532bc23dd7ae4808044788def084245R8-R9)
* Replaced custom schema validation logic with `zod` validation in `validateSchema` functions in `packages/directus-extension-cache-flush/src/utils.ts` and `packages/directus-extension-data-sync/src/utils.ts`. [[1]](diffhunk://#diff-c6b07a2447da08266d92ad04bcf9f4f247ec75b3c14f454a0c88ec38603f3389L25-R43) [[2]](diffhunk://#diff-70ddd7647d3bff315f680a42402a31beb532bc23dd7ae4808044788def084245L82-R98)

### Dependency Updates:
* Updated `pnpm-lock.yaml` to reflect the addition of `zod` and other dependency changes. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL43-R43) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL65-R68) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL96-R102) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL136-R148) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL164-R182) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL195-R201) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL217-R229) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7050-R7056) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7210-R7216) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7249-R7255) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7409-R7415) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7712-R7718)