### PR TITLE
fix: Skip linting and validation if dependabot PR

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,8 +16,8 @@ jobs:
   directus-validate:
     name: Validate
     runs-on: ubuntu-latest
-    # Skip if PR is from dependabot 
-    if: ${{ github.actor != 'dependabot[bot]' }} 
+    # Skip if PR is from dependabot
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,8 @@ jobs:
   directus-validate:
     name: Validate
     runs-on: ubuntu-latest
+    # Skip if PR is from dependabot 
+    if: ${{ github.actor != 'dependabot[bot]' }} 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # Skip if PR is from dependabot 
+    if: ${{ github.actor != 'dependabot[bot]' }} 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    # Skip if PR is from dependabot 
-    if: ${{ github.actor != 'dependabot[bot]' }} 
+    # Skip if PR is from dependabot
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/bash
+pnpm lint:fix


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows to skip certain jobs when the pull request is from Dependabot. The most important changes include modifying the `Validate` and `Lint` jobs to include a condition that skips these jobs if the actor is Dependabot.

Changes in GitHub workflows:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R19-R20): Added a condition to the `Validate` job to skip it if the PR is from Dependabot.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R19-R20): Added a condition to the `Lint` job to skip it if the PR is from Dependabot.