### PR TITLE
fix: Precommit lint fixes should be staged before commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,4 +8,7 @@ fi
 # Check if DISABLE_PRE_COMMIT_LINT is not set to true
 if [ "$DISABLE_PRE_COMMIT_LINT" != "true" ]; then
     pnpm lint:fix
+
+    # Add fixed files back to the staging area
+    git add .
 fi


### PR DESCRIPTION
This pull request includes an enhancement to the pre-commit hook script to ensure that fixed files are added back to the staging area after linting.

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR11-R13): Added a command to `git add .` after running `pnpm lint:fix` to ensure that fixed files are added back to the staging area.